### PR TITLE
Adding `CMPSC 100` to the data set

### DIFF
--- a/src/curriculumData/current_data.json
+++ b/src/curriculumData/current_data.json
@@ -49,7 +49,7 @@
         "Analyze and suggest revisions to existing Python language code to improve or add functionality",
         "Evaluate the practical and ethical implications of computer programs written to solve computational problems",
         "Design, describe, and implement original projects incorporating standard practices and Python language principles "
-      ],
+      ]
     },
     {
       "courseNumber": "CMPSC 102",

--- a/src/curriculumData/current_data.json
+++ b/src/curriculumData/current_data.json
@@ -32,18 +32,24 @@
       "topics": [
         "Object-oriented programming (OOP)",
         "Teamwork",
-        "Version control systems",
+        "Version control systems (VCS)",
         "Integrated development environments (IDE)",
         "Iteration",
-        "Python programming",
+        "Conditional logic",
+        "Variables",
         "Functions",
         "GitHub Flow",
         "Markdown"
       ],
       "tools": ["Python", "VSCode", "Git", "GitHub"],
-      "lab": [],
-      "learningObjectives": [],
-      "learningOutcomes": []
+      "platform": [],
+      "learningObjectives": [
+        "Apply Python programming language primitives to describe and develop computer programs that solve computational problems",
+        "Use VSCode, git, and GitHub to develop, version, and release code consistent with industry-standard practices",
+        "Analyze and suggest revisions to existing Python language code to improve or add functionality",
+        "Evaluate the practical and ethical implications of computer programs written to solve computational problems",
+        "Design, describe, and implement original projects incorporating standard practices and Python language principles "
+      ],
     },
     {
       "courseNumber": "CMPSC 102",


### PR DESCRIPTION
This `PR` adds the relevant details for `CMPSC 100` to the data set. It is missing a course platform value; I will work to complete the field over the next couple of days with an adequate, realistic platform page describing the course. Until then, this is a draft `PR`, and I will convert it to full `PR` status when ready.

Of note, there are data changes not yet implemented in the specification that might need some adjustment. Namely:

* `platform` instead of `lab`
* `learningObjectives` only, no `learningOutcomes`
* `professionalSkills` needs to be added, though I'm unsure of where in the hierarchy to do it; parallel with `topics`?