### PR TITLE
Adding `CMPSC 200` to the list of courses

### DIFF
--- a/src/curriculumData/current_data.json
+++ b/src/curriculumData/current_data.json
@@ -124,6 +124,13 @@
         "Digital circuits",
         "Low-level languages"
       ],
+      "professionalTopics": [
+        "Collaboration and teamwork",
+        "Analytical and critical thinking",
+        "Problem solving and troubleshooting",
+        "Research",
+        "Written and oral communication, and presentation"
+      ],
       "tools": ["Raspberry Pi Pico W", "C", "Assembly languages"],
       "platform": [],
       "learningObjectives": [

--- a/src/curriculumData/current_data.json
+++ b/src/curriculumData/current_data.json
@@ -116,9 +116,9 @@
       "infSub": "",
       "selevel": "",
       "topics": [
-        "Object-oriented programming",
         "Memory management",
-        "Declarative programming",
+        "Imperative programming",
+        "Procedural programming",
         "Instruction set architectures (ISA)",
         "Functional programming",
         "Digital circuits",
@@ -129,8 +129,8 @@
       "learningObjectives": [
         "Explain how programs written in high-level computer programming languages execute using lower-level computer circuitry",
         "Identify levels of the Memory Hierarchy and the implications of using the various levels to implement high-performance programs",
-        "Develop C and Assembly language programs which use the appropriate levels of the Memory Hierarchy and processor registers to create performant, executable programs and arithmetic logic units",
-        "Describe and use parallel processing techniques to increase a program’s performance and efficiency",
+        "Develop C and Assembly language programs which use the appropriate levels of the Memory Hierarchy and processor registers to create performant, executable programs and logic units",
+        "Describe and use threading to increase a program’s performance and efficiency",
         "Integrate third-party hardware and software components with original C language code to develop hardware-based, performant computational projects"
       ]
     },

--- a/src/curriculumData/current_data.json
+++ b/src/curriculumData/current_data.json
@@ -124,10 +124,15 @@
         "Digital circuits",
         "Low-level languages"
       ],
-      "tools": ["Docker", "Verilog", "C++", "Assembly"],
-      "lab": [],
-      "learningObjectives": [],
-      "learningOutcomes": []
+      "tools": ["Raspberry Pi Pico W", "C", "Assembly languages"],
+      "platform": [],
+      "learningObjectives": [
+        "Explain how programs written in high-level computer programming languages execute using lower-level computer circuitry",
+        "Identify levels of the Memory Hierarchy and the implications of using the various levels to implement high-performance programs",
+        "Develop C and Assembly language programs which use the appropriate levels of the Memory Hierarchy and processor registers to create performant, executable programs and arithmetic logic units",
+        "Describe and use parallel processing techniques to increase a program’s performance and efficiency",
+        "Integrate third-party hardware and software components with original C language code to develop hardware-based, performant computational projects"
+      ]
     },
     {
       "courseNumber": "CMPSC 104",

--- a/src/curriculumData/current_data.json
+++ b/src/curriculumData/current_data.json
@@ -115,14 +115,15 @@
       "inflevel": "",
       "infSub": "",
       "selevel": "",
-      "topics": [
+      "technicalTopics": [
         "Memory management",
         "Imperative programming",
         "Procedural programming",
         "Instruction set architectures (ISA)",
         "Functional programming",
         "Digital circuits",
-        "Low-level languages"
+        "Low-level languages",
+        "Hardware design languages (HDL)"
       ],
       "professionalTopics": [
         "Collaboration and teamwork",
@@ -131,14 +132,14 @@
         "Research",
         "Written and oral communication, and presentation"
       ],
-      "tools": ["Raspberry Pi Pico W", "C", "Assembly languages"],
+      "tools": ["Raspberry Pi Pico W", "C", "Assembly languages", "Verilog"],
       "platform": [],
       "learningObjectives": [
         "Explain how programs written in high-level computer programming languages execute using lower-level computer circuitry",
         "Identify levels of the Memory Hierarchy and the implications of using the various levels to implement high-performance programs",
         "Develop C and Assembly language programs which use the appropriate levels of the Memory Hierarchy and processor registers to create performant, executable programs and logic units",
         "Describe and use threading to increase a program’s performance and efficiency",
-        "Integrate third-party hardware and software components with original C language code to develop hardware-based, performant computational projects"
+        "Design and test digital circuits using the Verilog hardware design language (HDL)"
       ]
     },
     {


### PR DESCRIPTION
This `PR` adds `Computer Organization` to the list of classes.

As is true of the `100-Level` pull requests, there seems to be an underlying data issue with the `JSON` file; i.e. fields are still not added.